### PR TITLE
fix: solved mqtt secure issues with mosquitto

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[*]
+insert_final_newline = true
+indent_style = tab
+indent_size = 8
+trim_trailing_whitespace = true
+
+[*.md]
+indent_size = 4
+trim_trailing_whitespace = false
+
+[{*.go,*.go2}]
+ij_go_add_leading_space_to_comments = false
+ij_go_group_stdlib_imports = false

--- a/pkg/secure/mqttfactory.go
+++ b/pkg/secure/mqttfactory.go
@@ -81,24 +81,21 @@ func (factory MqttFactory) configureMQTTClientForAuth(secretData *messaging.Secr
 		// nolint: gosec
 		InsecureSkipVerify: factory.skipCertVerify,
 		MinVersion:         tls.VersionTLS12,
+		ClientAuth:         tls.NoClientCert,
 	}
 	// Username may be required when cert authentication
 	if secretData.Username != "" {
 		factory.opts.SetUsername(secretData.Username)
 	}
-	switch factory.authMode {
-	case messaging.AuthModeUsernamePassword:
+	if secretData.Password != "" {
 		factory.opts.SetPassword(secretData.Password)
-	case messaging.AuthModeCert:
+	}
+	if len(secretData.CertPemBlock) > 0 && len(secretData.KeyPemBlock) > 0 {
 		cert, err = tls.X509KeyPair(secretData.CertPemBlock, secretData.KeyPemBlock)
 		if err != nil {
 			return err
 		}
 		tlsConfig.Certificates = []tls.Certificate{cert}
-	case messaging.AuthModeCA:
-		// Nothing to do here for this option
-	case messaging.AuthModeNone:
-		return nil
 	}
 
 	if len(secretData.CaPemBlock) > 0 {

--- a/pkg/secure/mqttfactory_test.go
+++ b/pkg/secure/mqttfactory_test.go
@@ -21,6 +21,7 @@ package secure
 
 import (
 	mqtt "github.com/eclipse/paho.mqtt.golang"
+
 	"os"
 	"testing"
 
@@ -144,7 +145,7 @@ func TestConfigureMQTTClientForAuthWithCACert(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
 	assert.Equal(t, target.opts.Username, "Username")
-	assert.Empty(t, target.opts.Password)
+	assert.Equal(t, target.opts.Password, "Password")
 	assert.Nil(t, target.opts.TLSConfig.Certificates)
 }
 func TestConfigureMQTTClientForAuthWithClientCert(t *testing.T) {
@@ -160,7 +161,7 @@ func TestConfigureMQTTClientForAuthWithClientCert(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, target.opts.Username, "Username")
-	assert.Empty(t, target.opts.Password)
+	assert.Equal(t, target.opts.Password, "Password")
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.NotNil(t, target.opts.TLSConfig.RootCAs)
 }
@@ -178,7 +179,7 @@ func TestConfigureMQTTClientForAuthWithClientCertNoCA(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.Equal(t, target.opts.Username, messaging.SecretUsernameKey)
-	assert.Empty(t, target.opts.Password)
+	assert.Equal(t, target.opts.Password, messaging.SecretPasswordKey)
 	assert.NotNil(t, target.opts.TLSConfig.Certificates)
 	assert.Nil(t, target.opts.TLSConfig.RootCAs)
 }


### PR DESCRIPTION
Remove some restrictions of edge-x which are limiting the usage of mosquitto mqtt broker
- add editorconfig to prevent changes in styling
- adapt unittest to work with the now intended behavior

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails**  due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/app-functions-sdk-go/blob/main/.github/CONTRIBUTING.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
      <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->